### PR TITLE
Add missing fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,14 @@
   "keywords": [
     "theia-plugin"
   ],
+  "icon": "redhat-developer-icon.png",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/redhat-developer/omnisharp-theia-plugin"
+  },
+  "categories": [
+    "Programming Languages"
+  ],
   "version": "0.0.1",
   "license": "EPL-2.0",
   "files": [

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "format-code": "tsfmt -r",
     "watch": "tsc -watch",
     "compile": "tsc",
-    "build": "yarn run format-code && yarn run compile && theia:plugin pack"
+    "build": "yarn run format-code && yarn run compile && theia-plugin pack"
   },
   "engines": {
     "theiaPlugin": "latest",


### PR DESCRIPTION
1. add missing fields to make it compliant with VS code extensions
2. fix the alias name of the packager `theia:plugin` --> `theia-plugin`